### PR TITLE
Fix bug in `ContactService::Group#has_contact?`.

### DIFF
--- a/lib/shark/contact_service/group.rb
+++ b/lib/shark/contact_service/group.rb
@@ -4,7 +4,7 @@ module Shark
       has_many :contacts
 
       def has_contact?(contact_id)
-        return false  if relationships["contacts"].blank?
+        return false  if relationships["contacts"].blank? || relationships["contacts"]["data"].blank?
         relationships["contacts"]["data"].any? { |c| c["type"] == "contacts" && c["id"].to_s == contact_id.to_s }
       end
     end


### PR DESCRIPTION
Unless the client retrieves the group with `includes(:contacts)`, there is no data array to call `any?` on.

---

ARE YOU HATING THIS 1-LINE PULL REQUEST? FITE ME!