### PR TITLE
Release/v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
-#### Unreleased
+#### 2.4.1
+- [fix] Form Service: Added missing `versions` association to `Form`
 
 #### 2.4.0
 - added `Shark::Contact#consents` and `Shark::Contact#create_contract`

--- a/lib/shark/form_service/v2/form.rb
+++ b/lib/shark/form_service/v2/form.rb
@@ -4,6 +4,8 @@ module Shark
   module FormService
     module V2
       class Form < V2::Base
+        has_many :versions
+
         # @example
         #   form = Shark::FormService::V2::Form.find(id)
         #   form.activate

--- a/lib/shark/rspec/fake_contact_service/request.rb
+++ b/lib/shark/rspec/fake_contact_service/request.rb
@@ -32,7 +32,7 @@ module Shark
             log_info '[Shark][ContactService] Faking GET request'
             log_info request.uri.to_s
 
-            type = request.uri.path.split('/')[2]
+            type = request.uri.path.split('/')[-1]
             params = query_params_to_object(request.uri)
 
             objects = if %w[contacts accounts].include?(type) && params['filter'].present?
@@ -52,8 +52,8 @@ module Shark
             log_info '[Shark][ContactService] Faking GET request with ID'
             log_info request.uri.to_s
 
-            type = request.uri.path.split('/')[2]
-            id = request.uri.path.split('/')[3]
+            type = request.uri.path.split('/')[-2]
+            id = request.uri.path.split('/')[-1]
             query = request.uri.query_values
 
             object = cache.find(type, id)
@@ -84,11 +84,10 @@ module Shark
             log_info '[Shark][ContactService] Faking GET memberships request'
             log_info request.uri.to_s
 
-            type = request.uri.path.split('/')[2]
-            group_id = request.uri.path.split('/')[3]
+            group_id = request.uri.path.split('/')[-2]
             contact_id = query_params_to_object(request.uri)['filter']['contact_id']
 
-            group = cache.find(type, group_id)
+            group = cache.find('groups', group_id)
 
             if group.present?
               contacts = group.dig('relationships', 'contacts', 'data')
@@ -107,8 +106,8 @@ module Shark
             log_info "[Shark][ContactService] Faking PATCH request with body: #{request.body}"
             log_info request.uri.to_s
 
-            type = request.uri.path.split('/')[2]
-            id = request.uri.path.split('/')[3]
+            type = request.uri.path.split('/')[-2]
+            id = request.uri.path.split('/')[-1]
             parsed_data = JSON.parse(request.body)['data']
 
             object = cache.find(type, id)
@@ -134,8 +133,8 @@ module Shark
             log_info '[Shark][ContactService] Faking DELETE request'
             log_info request.uri.to_s
 
-            type = request.uri.path.split('/')[2]
-            id = request.uri.path.split('/')[3]
+            type = request.uri.path.split('/')[-2]
+            id = request.uri.path.split('/')[-1]
 
             object = cache.find(type, id)
 

--- a/lib/shark/version.rb
+++ b/lib/shark/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shark
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end


### PR DESCRIPTION
* Form Service: added missing `versions` association to `Form` (I did not create a `0.14.1` release I've used for the deleting surveys story in milaCRM...)
* Minor changes when stubbing Contact Service: almost all the specs in milaCRM failed after updating from `0.14.0` to the latest version, because the Shark RSpec Helper expected an URL like `https://contactservice.example.org/api`, but in milaCRM's settings it is `https://contactservice.example.org`.