### PR TITLE
Introduce with_auth_token to send custom Authorization header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-cache: bundler
+# cache: bundler
 rvm:
   - 2.7.6
   - 3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 3.1.0
+- Extend `with_service_token` with `with_auth_token` which allows to send custom `Authorization` header, not only `Bearer`
+
 #### 3.0.0
 - new minimum requirements are `Ruby 3.0` and `faraday 2.0`
 - remove `Shark::Subscription`

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ Shark::MailingService.use_shark_mailer do |mailer|
 end
 ```
 
+To sign your requests with custom tokens, for instance with JWT:
+```ruby
+  def deliver
+    access_id = 'access_id'
+    secret_key = 'secret_key'
+
+    signature = JWT.encode({ exp: Time.now.to_i + (1 * 60) }, secret_key, 'HS256')
+
+    Shark.with_auth_token("JWT #{access_id}:#{signature}") do
+      super
+    end
+  end
+
+```
+
 ## Testing
 
 ```

--- a/lib/shark.rb
+++ b/lib/shark.rb
@@ -34,26 +34,39 @@ module Shark
   # @api public
   def self.with_service_token(token)
     if token.is_a?(String)
-      self.service_token = token
+      auth_token = "Bearer #{token}"
     elsif token.respond_to?(:jwt)
-      self.service_token = token.jwt
+      auth_token = "Bearer #{token.jwt}"
     else
       raise ArgumentError, 'Parameter :token must be kind of String.'
     end
 
+    with_auth_token(auth_token)
+  end
+
+  # Within the given block, add the authorization header token to all api requests.
+  #
+  # @param token [String] The token for the authorization header
+  # @param block [Block] The block where authorization token will be set for
+  # @api public
+  def self.with_auth_token(token)
+    raise ArgumentError, 'Parameter :token must be kind of String.' unless token.is_a?(String)
+
+    self.auth_token = token
+
     yield
   ensure
-    self.service_token = nil
+    self.auth_token = nil
   end
 
   # @api public
-  def self.service_token
-    Thread.current['shark-service-token']
+  def self.auth_token
+    Thread.current['shark-auth-token']
   end
 
   # @api private
-  def self.service_token=(value)
-    Thread.current['shark-service-token'] = value
+  def self.auth_token=(value)
+    Thread.current['shark-auth-token'] = value
   end
 
   #

--- a/lib/shark/client/connection.rb
+++ b/lib/shark/client/connection.rb
@@ -38,9 +38,7 @@ module Shark
         request_headers = connection_options_headers.merge(headers || {})
         request_params = connection_options_params.merge(params || {})
 
-        if Shark.service_token.present?
-          request_headers['Authorization'] = "Bearer #{Shark.service_token}"
-        end
+        request_headers['Authorization'] = Shark.auth_token if Shark.auth_token.present?
 
         @connection.send(request_action) do |request|
           request.url(url)

--- a/lib/shark/version.rb
+++ b/lib/shark/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shark
-  VERSION = '3.0.0'
+  VERSION = '3.1.0'
 end


### PR DESCRIPTION
Allows to sign request with non-Bearer tokens.