### PR TITLE
version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+#### 3.1.1
+- Extend Shark::Configuration with `access_id` and `secret_key`
+
 #### 3.1.0
 - Extend `with_service_token` with `with_auth_token` which allows to send custom `Authorization` header, not only `Bearer`
 

--- a/bin/console
+++ b/bin/console
@@ -7,17 +7,11 @@ require 'shark'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-# TODO
 Shark.configure do |config|
   config.contact_service.site = 'https://contactservice-development.bundesimmo.de/api/'
   config.survey_service.site = 'https://milacrm-development.bundesimmo.de/api/v1/'
   config.form_service.site = 'https://formservice-development.bundesimmo.de/api/v1/'
   config.notification_service.site = 'https://api-development.bundesimmo.de/notification-service/'
-  config.subscription_service.site = 'https://api-development.bundesimmo.de/subscription-service/'
 end
 
 require 'irb'

--- a/lib/shark/configuration.rb
+++ b/lib/shark/configuration.rb
@@ -53,6 +53,7 @@ module Shark
     # Shark Configuration
     #
     attr_accessor :cache, :logger
+    attr_accessor :access_id, :secret_key
     attr_reader :contact_service
     attr_reader :consent_service
     attr_reader :double_opt_in

--- a/lib/shark/version.rb
+++ b/lib/shark/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shark
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Extend Shark::Configuration with `access_id` and `secret_key`.

Then we can even remove `bima-doorkeeper-rails` from `bima-uploader` and probably `bima-contact-form-service`.